### PR TITLE
✨ 51 - add permissions to groups panel

### DIFF
--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -58,6 +58,21 @@ import {
 import { IResource, TResourceType } from 'common/typedefs/Resource';
 import { Icon } from 'semantic-ui-react';
 
+import {
+  API_KEY,
+  API_KEYS,
+  APPLICATION,
+  APPLICATIONS,
+  GROUP,
+  GROUPS,
+  PERMISSION,
+  PERMISSIONS,
+  POLICIES,
+  POLICY,
+  USER,
+  USERS,
+} from 'common/enums';
+
 // ignore tslint sort, resources listed in deliberate order
 const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
   users: {
@@ -66,7 +81,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
       groups: ({ group, item }) => addGroupToUser({ user: item, group }),
     },
     addItem: true,
-    associatedTypes: ['groups', 'applications', 'permissions', 'API Keys'],
+    associatedTypes: [GROUPS, APPLICATIONS, PERMISSIONS, API_KEYS],
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
@@ -99,7 +114,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
         actionText: 'REMOVE',
       }));
     },
-    name: { singular: 'user', plural: 'users' },
+    name: { singular: USER, plural: USERS },
     noDelete: true,
     remove: {
       applications: ({ application, item }) =>
@@ -196,7 +211,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
       users: ({ user, item }) => addGroupToUser({ group: item, user }),
     },
     addItem: true,
-    associatedTypes: ['users', 'applications', 'permissions'],
+    associatedTypes: [USERS, APPLICATIONS, PERMISSIONS],
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
@@ -229,7 +244,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
         actionText: 'REMOVE',
       }));
     },
-    name: { singular: 'group', plural: 'groups' },
+    name: { singular: GROUP, plural: GROUPS },
     remove: {
       applications: ({ application, item }) =>
         removeApplicationFromGroup({ group: item, application }),
@@ -278,7 +293,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
       users: ({ user, item }) => addApplicationToUser({ application: item, user }),
     },
     addItem: true,
-    associatedTypes: ['groups', 'users'],
+    associatedTypes: [GROUPS, USERS],
     AssociatorComponent: null,
     childSchema: [],
     createItem: createApplication,
@@ -310,7 +325,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     isParent: true,
     ListItem: ApplicationListItem,
     mapTableData: results => results,
-    name: { singular: 'application', plural: 'applications' },
+    name: { singular: APPLICATION, plural: APPLICATIONS },
     remove: {
       groups: ({ group, item }) => removeApplicationFromGroup({ application: item, group }),
       users: ({ user, item }) => removeApplicationFromUser({ application: item, user }),
@@ -406,7 +421,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
         issueDate: moment(result.issueDate).format(DATE_FORMAT),
       }));
     },
-    name: { singular: 'API Key', plural: 'API Keys' },
+    name: { singular: 'API Key', plural: API_KEYS },
     rowHeight: 44,
     schema: [
       {
@@ -477,7 +492,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     initialSortOrder: 'ASC',
     isParent: false,
     ListItem: PermissionListItem,
-    name: { singular: 'permission', plural: 'permissions' },
+    name: { singular: PERMISSION, plural: PERMISSIONS },
     mapTableData(results) {
       return results.map(result => ({
         accessLevel: result.accessLevel,
@@ -524,7 +539,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
       users: ({ user, item }) => addUserPermissionToPolicy({ policy: item, user }),
     },
     addItem: false,
-    associatedTypes: ['groups', 'users'],
+    associatedTypes: [GROUPS, USERS],
     AssociatorComponent: PermissionsTable,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
@@ -561,7 +576,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     isParent: true,
     ListItem: PolicyListItem,
     mapTableData: results => results,
-    name: { singular: 'policy', plural: 'policies' },
+    name: { singular: POLICY, plural: POLICIES },
     remove: {
       groups: ({ group, item }) => removeGroupPermissionFromPolicy({ policy: item, group }),
       users: ({ user, item }) => removeUserPermissionFromPolicy({ policy: item, user }),

--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -70,7 +70,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
-      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: sort disabled until backend is fixed
+      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: cannot sort on name field, need join to User, related to EGO-452
       { key: 'mask', fieldName: 'Access Level', sortable: true },
       { key: 'action', fieldName: 'Action', sortable: false },
     ],
@@ -200,7 +200,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
-      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: sort disabled until backend is fixed
+      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: cannot sort on name field, need join to Group, related to EGO-452
       { key: 'mask', fieldName: 'Access Level', sortable: true },
       { fieldName: 'Action', key: 'action', sortable: false },
     ],

--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -481,9 +481,11 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     mapTableData(results) {
       return results.map(result => ({
         accessLevel: result.accessLevel,
-        id: result.id,
+        id: result.policy.id,
         ownerType: result.ownerType,
         policy: result.policy.name,
+        action: 'remove',
+        actionText: 'REMOVE',
       }));
     },
     rowHeight: 44,
@@ -507,6 +509,12 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
         key: 'ownerType',
         required: true,
         sortable: true,
+      },
+      {
+        fieldName: 'Action',
+        key: 'action',
+        required: false,
+        sortable: false,
       },
     ],
   },

--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -20,6 +20,7 @@ import {
   getApp,
   getApps,
   getGroup,
+  getGroupPermissions,
   getGroups,
   getPolicies,
   getPolicy,
@@ -187,10 +188,15 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
   groups: {
     add: {
       applications: ({ application, item }) => addApplicationToGroup({ group: item, application }),
+      permissions: ({ permission, item }) =>
+        addGroupPermissionToPolicy({
+          group: { ...item, mask: permission.mask },
+          policy: permission,
+        }),
       users: ({ user, item }) => addGroupToUser({ group: item, user }),
     },
     addItem: true,
-    associatedTypes: ['users', 'applications'],
+    associatedTypes: ['users', 'applications', 'permissions'],
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
@@ -227,6 +233,8 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     remove: {
       applications: ({ application, item }) =>
         removeApplicationFromGroup({ group: item, application }),
+      permissions: ({ permission, item }) =>
+        removeGroupPermissionFromPolicy({ group: item, policy: permission }),
       users: ({ user, item }) => removeGroupFromUser({ group: item, user }),
     },
     rowHeight: 44,
@@ -441,9 +449,15 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     ],
   },
   permissions: {
-    addItem: false,
+    addItem: {
+      groups: true,
+      users: false,
+    },
     associatedTypes: [],
-    AssociatorComponent: UserPermissionsTable,
+    AssociatorComponent: {
+      groups: PermissionsTable,
+      users: UserPermissionsTable,
+    },
     childSchema: [],
     emptyMessage: '',
     initialSortField(isChildOfPolicy: boolean) {
@@ -453,7 +467,10 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
       return (isChildOfPolicy ? this.childSchema : this.schema).filter(field => field.sortable);
     },
     getKey: item => item.id.toString(),
-    getList: getUserAndUserGroupPermissions,
+    getList: {
+      groups: getGroupPermissions,
+      users: getUserAndUserGroupPermissions,
+    },
     getListAll: getPolicies,
     getName: item => get(item, 'name'),
     Icon: () => null,

--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -70,7 +70,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
-      { key: 'name', fieldName: 'Name', sortable: true },
+      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: sort disabled until backend is fixed
       { key: 'mask', fieldName: 'Access Level', sortable: true },
       { key: 'action', fieldName: 'Action', sortable: false },
     ],
@@ -200,7 +200,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     AssociatorComponent: null,
     childSchema: [
       { key: 'id', fieldName: 'ID', sortable: true, initialSort: true },
-      { key: 'name', fieldName: 'Name', sortable: true },
+      { key: 'name', fieldName: 'Name', sortable: false }, // TODO: sort disabled until backend is fixed
       { key: 'mask', fieldName: 'Access Level', sortable: true },
       { fieldName: 'Action', key: 'action', sortable: false },
     ],

--- a/src/common/associatedUtils.ts
+++ b/src/common/associatedUtils.ts
@@ -1,5 +1,7 @@
 import { get, isEmpty } from 'lodash';
 
+import { API_KEY, GROUP, PERMISSION, POLICY, USER } from 'common/enums';
+
 const getResourceName = resource => get(resource, 'name.singular');
 const hasParent = parent => !isEmpty(parent);
 
@@ -9,11 +11,11 @@ const isGroupPermission = (parent, child) =>
 const isUserPermission = (parent, child) =>
   hasParent(parent) && isUser(parent) && isPermission(child);
 
-const isPolicy = resource => getResourceName(resource) === 'policy';
-const isPermission = resource => getResourceName(resource) === 'permission';
-const isUser = resource => getResourceName(resource) === 'user';
-const isGroup = resource => getResourceName(resource) === 'group';
-const isApiKey = resource => getResourceName(resource) === 'API Key';
+const isPolicy = resource => getResourceName(resource) === POLICY;
+const isPermission = resource => getResourceName(resource) === PERMISSION;
+const isUser = resource => getResourceName(resource) === USER;
+const isGroup = resource => getResourceName(resource) === GROUP;
+const isApiKey = resource => getResourceName(resource) === API_KEY;
 
 export {
   isChildOfPolicy,

--- a/src/common/associatedUtils.ts
+++ b/src/common/associatedUtils.ts
@@ -1,0 +1,28 @@
+import { get, isEmpty } from 'lodash';
+
+const getResourceName = resource => get(resource, 'name.singular');
+const hasParent = parent => !isEmpty(parent);
+
+const isChildOfPolicy = parent => hasParent(parent) && isPolicy(parent);
+const isGroupPermission = (parent, child) =>
+  hasParent(parent) && isGroup(parent) && isPermission(child);
+const isUserPermission = (parent, child) =>
+  hasParent(parent) && isUser(parent) && isPermission(child);
+
+const isPolicy = resource => getResourceName(resource) === 'policy';
+const isPermission = resource => getResourceName(resource) === 'permission';
+const isUser = resource => getResourceName(resource) === 'user';
+const isGroup = resource => getResourceName(resource) === 'group';
+const isApiKey = resource => getResourceName(resource) === 'API Key';
+
+export {
+  isChildOfPolicy,
+  isGroupPermission,
+  isUserPermission,
+  isApiKey,
+  isPolicy,
+  isPermission,
+  isUser,
+  isGroup,
+  hasParent,
+};

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -1,0 +1,28 @@
+const PERMISSIONS = 'permissions';
+const USERS = 'users';
+const GROUPS = 'groups';
+const APPLICATIONS = 'applications';
+const API_KEYS = 'API Keys';
+const POLICIES = 'policies';
+
+const PERMISSION = 'permission';
+const USER = 'user';
+const GROUP = 'group';
+const APPLICATION = 'application';
+const API_KEY = 'API Key';
+const POLICY = 'policy';
+
+export {
+  API_KEY,
+  API_KEYS,
+  APPLICATION,
+  APPLICATIONS,
+  GROUP,
+  GROUPS,
+  PERMISSION,
+  PERMISSIONS,
+  POLICY,
+  POLICIES,
+  USER,
+  USERS,
+};

--- a/src/common/typedefs/Resource.d.ts
+++ b/src/common/typedefs/Resource.d.ts
@@ -101,8 +101,8 @@ interface IAddToUser {
     application: Application,
     item: User,
   ) => (user: { item: User }, application: any) => Promise<User>;
-  // groups: (group: Group, item: User) => Promise<any>;
-  // permissions: (permission: UserPermission, item: User) => Promise<any>;
+  groups: (group: Group, item: User) => Promise<any>;
+  permissions: (permission: UserPermission, item: User) => Promise<any>;
 }
 
 interface IAddToGroup {
@@ -129,7 +129,7 @@ export interface IResource {
   noDelete?: true;
   name: { singular: string; plural: TResourceType };
   ListItem: JSX.Element<any>;
-  // getList: (params: IListParams) => Promise<IListResponse> | IPermissionsGetList;
+  // getList can now be a hashmap
   getList: any;
   getListAll: (params: IListParams) => Promise<IListResponse>;
   getItem?: TGetItem;
@@ -150,10 +150,8 @@ export interface IResource {
   remove?: any;
   getKey: Function;
   mapTableData: Function;
-  // add: { [key in TResourceType]?: (params: any) => Promise<any> };
   // remove: { [key in TResourceType]?: (params: any) => Promise<any> };
   sortableFields: Schema;
   isParent: boolean;
-  AssociatorComponent: any;
-  // AssociatorComponent?: JSX.Element<{ associatedItems: any[] }> | null;
+  AssociatorComponent?: JSX.Element<{ associatedItems: any[] }> | null;
 }

--- a/src/common/typedefs/Resource.d.ts
+++ b/src/common/typedefs/Resource.d.ts
@@ -108,11 +108,17 @@ interface IAddToUser {
 interface IAddToGroup {
   applications: (application: Application, item: ICreateApplication) => Promise<any>;
   users: (user: User, item: ICreateUser) => Promise<any>;
+  permissions: (permission: Permission, item: ICreateGroup) => Promise<any>;
 }
 
 interface IAddToApplication {
   groups: (group: Group, item: ICreateGroup) => Promise<any>;
   users: (user: User, item: ICreateUser) => Promise<any>;
+}
+
+interface IPermissionsGetList {
+  groups: (params: IListParams) => Promise<IListResponse>;
+  users: (params: IListParams) => Promise<IListResponse>;
 }
 
 export interface IResource {
@@ -123,7 +129,8 @@ export interface IResource {
   noDelete?: true;
   name: { singular: string; plural: TResourceType };
   ListItem: JSX.Element<any>;
-  getList: (params: IListParams) => Promise<IListResponse>;
+  // getList: (params: IListParams) => Promise<IListResponse> | IPermissionsGetList;
+  getList: any;
   getListAll: (params: IListParams) => Promise<IListResponse>;
   getItem?: TGetItem;
   updateItem?: (
@@ -138,7 +145,7 @@ export interface IResource {
   associatedTypes: Types[];
   initialSortField: (any) => string;
   childSchema?: Schema;
-  addItem: boolean;
+  addItem: boolean | { groups: boolean; users: boolean };
   add?: IAddToUser | IAddToGroup | IAddToApplication | any;
   remove?: any;
   getKey: Function;
@@ -147,5 +154,6 @@ export interface IResource {
   // remove: { [key in TResourceType]?: (params: any) => Promise<any> };
   sortableFields: Schema;
   isParent: boolean;
-  AssociatorComponent?: JSX.Element<{ associatedItems: any[] }> | null;
+  AssociatorComponent: any;
+  // AssociatorComponent?: JSX.Element<{ associatedItems: any[] }> | null;
 }

--- a/src/common/typedefs/Resource.d.ts
+++ b/src/common/typedefs/Resource.d.ts
@@ -1,3 +1,4 @@
+import { API_KEYS, APPLICATIONS, GROUPS, PERMISSIONS, POLICIES, USERS } from 'common/enums';
 import { ApiKey } from 'common/typedefs/ApiKey';
 import { Application } from 'common/typedefs/Application';
 import { Group } from 'common/typedefs/Group';
@@ -21,26 +22,31 @@ export interface IField {
 
 export type ISchema = IField[];
 
-export type TResourceType =
-  | 'groups'
-  | 'applications'
-  | 'users'
-  | 'API Keys'
-  | 'permissions'
-  | 'policies';
+export type TResourceType = GROUPS | APPLICATIONS | USERS | API_KEYS | PERMISSIONS | POLICIES;
 
 export type TSortDirection = 'DESC' | 'ASC';
 
-interface IListParams {
+interface IBaseListParams {
   offset?: number = null;
   limit?: number = null;
   query?: any = null;
   sortField?: any = null;
   sortOrder?: any = null;
+}
+
+interface IListParams extends IBaseListParams {
   applicationId?: any = null;
   groupId?: any = null;
   userId?: any = null;
   status?: any = null;
+}
+
+interface IGroupPermissionParams extends IBaseListParams {
+  groupId: string;
+}
+
+interface IUserPermissionParams extends IBaseListParams {
+  userId: string;
 }
 
 interface IListResponse {
@@ -117,9 +123,11 @@ interface IAddToApplication {
 }
 
 interface IPermissionsGetList {
-  groups: (params: IListParams) => Promise<IListResponse>;
-  users: (params: IListParams) => Promise<IListResponse>;
+  groups: (params: IGroupPermissionParams) => Promise<IListResponse>;
+  users: (params: IUserPermissionParams) => Promise<IListResponse>;
 }
+
+type TGetList = (params: IListParams) => Promise<IListResponse>;
 
 export interface IResource {
   Icon: any;
@@ -129,10 +137,9 @@ export interface IResource {
   noDelete?: true;
   name: { singular: string; plural: TResourceType };
   ListItem: JSX.Element<any>;
-  // getList can now be a hashmap
-  getList: any;
+  getList: TGetList | IPermissionsGetList;
   getListAll: (params: IListParams) => Promise<IListResponse>;
-  getItem?: TGetItem;
+  getItem?: TGetItem | undefined;
   updateItem?: (
     item: ICreateUser | ICreateGroup | ICreateApplication,
   ) => Promise<User | Group | Application>;

--- a/src/components/Associator/ApiKeysTable.tsx
+++ b/src/components/Associator/ApiKeysTable.tsx
@@ -2,7 +2,7 @@ import { css } from 'glamor';
 import { upperCase } from 'lodash';
 import moment from 'moment';
 import React, { CSSProperties } from 'react';
-import { compose, withHandlers, withState } from 'recompose';
+import { compose, withHandlers, withPropsOnChange, withState } from 'recompose';
 import { Button, Grid, Label } from 'semantic-ui-react';
 
 import { DARK_GREY, DEFAULT_BLACK, GREY, LIGHT_RED, LIGHT_TEAL } from 'common/colors';
@@ -89,6 +89,9 @@ const enhance = compose(
       setItems(response.resultSet);
     },
   }),
+  withPropsOnChange(['associatedItems'], ({ associatedItems, setItems }) =>
+    setItems(associatedItems),
+  ),
 );
 
 const ApiKeysTable = ({ disabledItems, editing, handleAction, items }) => {

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -134,11 +134,17 @@ class Associator extends React.Component<TProps, any> {
       type,
       parentId,
     }: any = this.props;
-
     const AssociatorComponent =
-      type === 'permissions' || type === 'API Keys'
+      type === 'permissions'
+        ? RESOURCE_MAP[type].AssociatorComponent[resource.name.plural]
+        : type === 'API Keys'
         ? RESOURCE_MAP[type].AssociatorComponent
         : resource.AssociatorComponent;
+
+    const includeAddButton =
+      type === 'permissions'
+        ? RESOURCE_MAP[type].addItem[resource.name.plural]
+        : RESOURCE_MAP[type].addItem;
 
     return (
       <div className={`Associator ${css(styles.container)}`}>
@@ -160,7 +166,7 @@ class Associator extends React.Component<TProps, any> {
           >
             {type === 'API Keys' ? 'API Keys' : capitalize(type)}
           </span>
-          {editing && RESOURCE_MAP[type].addItem && (
+          {editing && includeAddButton && (
             <ItemSelector
               fetchItems={args => fetchItems({ ...args, limit: 10 })}
               onSelect={item => addItem(item, type)}

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -151,26 +151,26 @@ const Associator = ({
   }, []);
 
   const AssociatorComponent =
-      type === 'permissions'
-        ? RESOURCE_MAP[type].AssociatorComponent[resource.name.plural]
-        : type === 'API Keys'
-        ? RESOURCE_MAP[type].AssociatorComponent
-        : resource.AssociatorComponent;
+    type === 'permissions'
+      ? RESOURCE_MAP[type].AssociatorComponent[resource.name.plural]
+      : type === 'API Keys'
+      ? RESOURCE_MAP[type].AssociatorComponent
+      : resource.AssociatorComponent;
 
   const includeAddButton =
-      type === 'permissions'
-        ? RESOURCE_MAP[type].addItem[resource.name.plural]
-        : RESOURCE_MAP[type].addItem;
+    type === 'permissions'
+      ? RESOURCE_MAP[type].addItem[resource.name.plural]
+      : RESOURCE_MAP[type].addItem;
 
-    const parsedAssocItems =
-      type === 'permissions' && isGroup(resource)
-        ? allAssociatedItems.map(assoc => ({
-            accessLevel: assoc.accessLevel,
-            id: assoc.policy.id,
-            name: assoc.policy.name,
-          }))
-        : allAssociatedItems;
-  
+  const parsedAssocItems =
+    type === 'permissions' && isGroup(resource)
+      ? allAssociatedItems.map(assoc => ({
+          accessLevel: assoc.accessLevel,
+          id: assoc.policy.id,
+          name: assoc.policy.name,
+        }))
+      : allAssociatedItems;
+
   return (
     <div className={`Associator ${css(styles.container)}`}>
       <div
@@ -192,26 +192,26 @@ const Associator = ({
           {type === 'API Keys' ? 'API Keys' : capitalize(type)}
         </span>
         {editing && includeAddButton && (
-            <ItemSelector
-              fetchItems={args => fetchItems({ ...args, limit: 1000 })}
-              onSelect={item => addItem(item, type)}
-              disabledItems={uniqBy([...parsedAssocItems, ...itemsInList], item => item && item.id)}
-            />
-          )}
+          <ItemSelector
+            fetchItems={args => fetchItems({ ...args, limit: 1000 })}
+            onSelect={item => addItem(item, type)}
+            disabledItems={uniqBy([...parsedAssocItems, ...itemsInList], item => item && item.id)}
+          />
+        )}
       </div>
       {itemsInList && itemsInList.length > 0 ? (
         AssociatorComponent ? (
           <AssociatorComponent
-              editing={editing}
-              associatedItems={itemsInList}
-              removeItem={item => removeItem(item, type)}
-              onSelect={item => addItem(item, type)}
-              type={type}
-              fetchItems={args => RESOURCE_MAP[type].getListAll({ ...args, limit: 5 })}
-              onRemove={RESOURCE_MAP[type].deleteItem}
-              parentId={parentId}
-              resource={resource}
-            />
+            editing={editing}
+            associatedItems={itemsInList}
+            removeItem={item => removeItem(item, type)}
+            onSelect={item => addItem(item, type)}
+            type={type}
+            fetchItems={args => RESOURCE_MAP[type].getListAll({ ...args, limit: 5 })}
+            onRemove={RESOURCE_MAP[type].deleteItem}
+            parentId={parentId}
+            resource={resource}
+          />
         ) : (
           itemsInList.map(item => (
             <Label key={getKey(item)} style={{ marginBottom: '0.27em' }}>

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -12,6 +12,8 @@ import { IResource } from 'common/typedefs/Resource';
 import { styles as contentStyles } from 'components/Content/ContentPanelView';
 import ItemSelector from './ItemSelector';
 
+import { isGroup } from 'common/associatedUtils';
+
 interface TProps {
   addItem: Function;
   allAssociatedItems: any[];
@@ -74,7 +76,7 @@ const enhance = compose(
   withStateHandlers(
     ({ initialItems, resource, type }) => {
       const parsedItems =
-        resource.name.singular === 'group' && type === 'permissions'
+        isGroup(resource) && type === 'permissions'
           ? initialItems.map(item => getParsedItem(item))
           : initialItems;
       return { allAssociatedItems: [], itemsInList: parsedItems || [] };
@@ -96,9 +98,7 @@ const enhance = compose(
       setAllAssociatedItems: () => allAssociatedItems => ({ allAssociatedItems }),
       setItemsInList: ({ itemsInList }, { resource, type }) => items => ({
         itemsInList:
-          resource.name.singular === 'group' && type === 'permissions'
-            ? items.map(i => getParsedItem(i))
-            : items,
+          isGroup(resource) && type === 'permissions' ? items.map(i => getParsedItem(i)) : items,
       }),
     },
   ),

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -14,6 +14,7 @@ import { styles as contentStyles } from 'components/Content/ContentPanelView';
 import ItemSelector from './ItemSelector';
 
 import { isGroup } from 'common/associatedUtils';
+import { API_KEYS, PERMISSIONS, USERS } from 'common/enums';
 
 interface TProps {
   addItem: Function;
@@ -78,7 +79,7 @@ const enhance = compose(
   withStateHandlers(
     ({ initialItems, resource, type }) => {
       const parsedItems =
-        isGroup(resource) && type === 'permissions'
+        isGroup(resource) && type === PERMISSIONS
           ? (initialItems || []).map(item => getParsedItem(item))
           : initialItems;
       return { allAssociatedItems: [], itemsInList: parsedItems || [] };
@@ -100,7 +101,7 @@ const enhance = compose(
       setAllAssociatedItems: () => allAssociatedItems => ({ allAssociatedItems }),
       setItemsInList: ({ itemsInList }, { resource, type }) => items => ({
         itemsInList:
-          isGroup(resource) && type === 'permissions'
+          isGroup(resource) && type === PERMISSIONS
             ? (items || []).map(i => getParsedItem(i))
             : items,
       }),
@@ -151,19 +152,19 @@ const Associator = ({
   }, []);
 
   const AssociatorComponent =
-    type === 'permissions'
+    type === PERMISSIONS
       ? RESOURCE_MAP[type].AssociatorComponent[resource.name.plural]
-      : type === 'API Keys'
+      : type === API_KEYS
       ? RESOURCE_MAP[type].AssociatorComponent
       : resource.AssociatorComponent;
 
   const includeAddButton =
-    type === 'permissions'
+    type === PERMISSIONS
       ? RESOURCE_MAP[type].addItem[resource.name.plural]
       : RESOURCE_MAP[type].addItem;
 
   const parsedAssocItems =
-    type === 'permissions' && isGroup(resource)
+    type === PERMISSIONS && isGroup(resource)
       ? allAssociatedItems.map(assoc => ({
           accessLevel: assoc.accessLevel,
           id: assoc.policy.id,
@@ -189,7 +190,7 @@ const Associator = ({
             styles.fieldName,
           )}`}
         >
-          {type === 'API Keys' ? 'API Keys' : capitalize(type)}
+          {type === API_KEYS ? API_KEYS : capitalize(type)}
         </span>
         {editing && includeAddButton && (
           <ItemSelector
@@ -215,7 +216,7 @@ const Associator = ({
         ) : (
           itemsInList.map(item => (
             <Label key={getKey(item)} style={{ marginBottom: '0.27em' }}>
-              {type === 'users' && !item.firstName
+              {type === USERS && !item.firstName
                 ? get(item, 'name')
                 : RESOURCE_MAP[type].getName(item)}
               {editing && <Icon name="delete" onClick={() => removeItem(item)} />}

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -77,7 +77,7 @@ const enhance = compose(
     ({ initialItems, resource, type }) => {
       const parsedItems =
         isGroup(resource) && type === 'permissions'
-          ? initialItems.map(item => getParsedItem(item))
+          ? (initialItems || []).map(item => getParsedItem(item))
           : initialItems;
       return { allAssociatedItems: [], itemsInList: parsedItems || [] };
     },
@@ -98,7 +98,9 @@ const enhance = compose(
       setAllAssociatedItems: () => allAssociatedItems => ({ allAssociatedItems }),
       setItemsInList: ({ itemsInList }, { resource, type }) => items => ({
         itemsInList:
-          isGroup(resource) && type === 'permissions' ? items.map(i => getParsedItem(i)) : items,
+          isGroup(resource) && type === 'permissions'
+            ? (items || []).map(i => getParsedItem(i))
+            : items,
       }),
     },
   ),

--- a/src/components/Associator/ItemSelector.tsx
+++ b/src/components/Associator/ItemSelector.tsx
@@ -22,10 +22,10 @@ const matchFor = (query: string | null, accessor) => item =>
 
 const enhance = compose(
   defaultProps({
-    getName: item => get(item, 'name'),
-    getKey: item => get(item, 'id'),
-    onSelect: item => global.log('selected', item),
     disabledItems: [],
+    getKey: item => get(item, 'id'),
+    getName: item => get(item, 'name'),
+    onSelect: item => global.log('selected', item),
   }),
   withState('isEntryMode', 'setIsEntryMode', false),
   withState('items', 'setItems', []),
@@ -80,10 +80,10 @@ const render = ({
               <Menu
                 className={`OptionList ${css(styles.optionsWrapper)}`}
                 size="small"
-                style={{ zIndex: 1 }}
+                style={{ zIndex: 1, overflowY: 'auto', maxHeight: 250 }}
                 vertical
               >
-                {differenceBy(items, disabledItems, 'id')
+                {differenceBy(items, disabledItems, item => item && item.id)
                   .filter(matchFor(inputValue, getName))
                   .map((item, i) => {
                     const isDisabled = disabledItems.map(getKey).includes(getKey(item));

--- a/src/components/Associator/ItemSelector.tsx
+++ b/src/components/Associator/ItemSelector.tsx
@@ -80,7 +80,7 @@ const render = ({
               <Menu
                 className={`OptionList ${css(styles.optionsWrapper)}`}
                 size="small"
-                style={{ zIndex: 1, overflowY: 'auto', maxHeight: 250 }}
+                style={{ zIndex: 1, overflowY: 'auto', maxHeight: 220 }}
                 vertical
               >
                 {differenceBy(items, disabledItems, item => item && item.id)

--- a/src/components/Associator/ItemSelector.tsx
+++ b/src/components/Associator/ItemSelector.tsx
@@ -83,23 +83,24 @@ const render = ({
                 style={{ zIndex: 1 }}
                 vertical
               >
-                {items.filter(matchFor(inputValue, getName)).map((item, i) => {
-                  const isDisabled = disabledItems.map(getKey).includes(getKey(item));
-                  return (
-                    <Menu.Item
-                      key={getKey(item)}
-                      {...getItemProps({
-                        disabled: isDisabled,
-                        item,
-                      })}
-                      active={highlightedIndex === i}
-                      disabled={isDisabled}
-                    >
-                      {getName(item)}
-                    </Menu.Item>
-                  );
-                })}
-                {!items.length && <Menu.Item>No Results</Menu.Item>}
+                {items &&
+                  items.filter(matchFor(inputValue, getName)).map((item, i) => {
+                    const isDisabled = disabledItems.map(getKey).includes(getKey(item));
+                    return (
+                      <Menu.Item
+                        key={getKey(item)}
+                        {...getItemProps({
+                          disabled: isDisabled,
+                          item,
+                        })}
+                        active={highlightedIndex === i}
+                        disabled={isDisabled}
+                      >
+                        {getName(item)}
+                      </Menu.Item>
+                    );
+                  })}
+                {items && !items.length && <Menu.Item>No Results</Menu.Item>}
               </Menu>
             </div>
           ) : (

--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -52,39 +52,17 @@ const enhance = compose(
     onSelect: item => global.log('selected', item),
   }),
   withState('items', 'setItems', ({ associatedItems }) => associatedItems),
-  withProps(
-    ({
-      onSelect,
-      fetchItems,
-      setItems,
-      disabledItems,
-      getKey,
-      newPermission,
-      setNewPermission,
-      type,
-      effects: { stageChange },
-      state: {
-        entity: { associated },
-      },
-    }) => ({
-      handleSelectMask: async (permission, mask) => {
-        if (permission.mask) {
-          return stageChange({
-            [type]: { add: { ...permission, mask } },
-          });
-        }
-        const selectedItem = find(associated[type].add, assoc => assoc.id === permission.id);
-
-        await stageChange({
-          [type]: { add: { ...selectedItem, mask } },
-        });
-      },
-      requestItems: async query => {
-        const response = await fetchItems({ query });
-        setItems(response.resultSet);
-      },
-    }),
-  ),
+  withProps(({ fetchItems, setItems, type, effects: { stageChange } }) => ({
+    handleSelectMask: (permission, mask) => {
+      stageChange({
+        [type]: { add: { ...permission, mask } },
+      });
+    },
+    requestItems: async query => {
+      const response = await fetchItems({ query });
+      setItems(response.resultSet);
+    },
+  })),
   withHandlers({
     handleStateChange: ({ requestItems }) => async (changes, stateAndHelpers) => {
       if (

--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -46,7 +46,6 @@ const EditMask = compose(withState('checkedMask', 'setCheckedMask', props => pro
 const enhance = compose(
   injectState,
   defaultProps({
-    disabledItems: [],
     getKey: item => get(item, 'id'),
     getName: item => get(item, 'name'),
     onSelect: item => global.log('selected', item),
@@ -83,7 +82,6 @@ const PermissionsTable = ({
   handleSelect,
   getName,
   handleStateChange,
-  disabledItems,
   getKey,
   items,
   handleAddNew,

--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -74,6 +74,7 @@ const enhance = compose(
           });
         }
         const selectedItem = find(associated[type].add, assoc => assoc.id === permission.id);
+
         await stageChange({
           [type]: { add: { ...selectedItem, mask } },
         });

--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -88,8 +88,6 @@ const PermissionsTable = ({
   items,
   handleAddNew,
   handleSelectMask,
-  newPermission,
-  setNewPermission,
   type,
   state: {
     entity: { associated },

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -94,7 +94,7 @@ class Content extends React.Component<any, IContentState> {
       rows,
       styles: stylesProp = {},
       id,
-      effects: { saveChanges, deleteItem, stageChange, refreshList },
+      effects: { saveChanges, deleteItem, stageChange, refreshList, undoChanges },
       state: {
         entity: { item, valid },
       },
@@ -187,7 +187,10 @@ class Content extends React.Component<any, IContentState> {
       <RippleButton
         basic
         disabled={isSaving}
-        onClick={() => history.push(`/${resource.name.plural}/${this.lastValidId || ''}`)}
+        onClick={async () => {
+          await undoChanges();
+          history.push(`/${resource.name.plural}/${this.lastValidId || ''}`);
+        }}
         size="tiny"
         style={{ fontWeight: 'bold' }}
       >

--- a/src/components/Content/ContentPanelView.tsx
+++ b/src/components/Content/ContentPanelView.tsx
@@ -7,6 +7,7 @@ import { compose } from 'recompose';
 import { Grid } from 'semantic-ui-react';
 
 import { DARK_GREY, GREY, HIGH_CONTRAST_TEAL } from 'common/colors';
+import { USER } from 'common/enums';
 
 const FIELD_NAME_WIDTHS = {
   application: 5,
@@ -103,7 +104,7 @@ const ContentView = ({
       {panelSections['meta'] && panelSections['meta'].length > 0 && (
         <div className={`contentPanel meta ${css(styles.section)}`}>
           <Grid columns="equal">
-            {entityType === 'user' ? (
+            {entityType === USER ? (
               <React.Fragment>
                 <Grid.Row className={`${css(styles.contentRow, styles.contentHeight)}`}>
                   {panelSections['meta'].slice(0, 2).map(({ fieldContent, fieldName, key }) => {
@@ -123,7 +124,7 @@ const ContentView = ({
                           <span
                             className={`contentFieldContent ${css(
                               styles.fieldContent,
-                              ...(entityType === 'user' &&
+                              ...(entityType === USER &&
                               key === 'type' &&
                               typeof fieldContent === 'string' &&
                               (fieldContent || '').toLowerCase() === 'admin'

--- a/src/components/Content/EditingContentPanel.tsx
+++ b/src/components/Content/EditingContentPanel.tsx
@@ -13,12 +13,12 @@ import { getUserFieldName } from './ContentPanel';
 import ContentPanelView from './ContentPanelView';
 
 const getFieldContent = (row, data, immutableKeys, stageChange) =>
-  row.fieldContent || // fieldContent is for associatedTypes
+  row.fieldContent ||
   (immutableKeys.includes(row.key)
     ? DATE_KEYS.indexOf(row.key) >= 0
       ? format(data[row.key], DATE_FORMAT)
       : data[row.key] || ''
-    : rowInput({ row, data, stageChange })); // for all mutable fields
+    : rowInput({ row, data, stageChange }));
 
 function rowInput({
   data,
@@ -38,7 +38,7 @@ function rowInput({
           selection
           style={{ minWidth: '9rem', fontSize: '12px' }}
           text={data[row.key]}
-          placeholder={`Select ${(row.fieldName || '').toLowerCase()}`}
+          placeholder={data[row.key] ? undefined : `Select ${(row.fieldName || '').toLowerCase()}`}
         />
       );
     default:

--- a/src/components/Content/EditingContentPanel.tsx
+++ b/src/components/Content/EditingContentPanel.tsx
@@ -38,6 +38,7 @@ function rowInput({
           selection
           style={{ minWidth: '9rem', fontSize: '12px' }}
           text={data[row.key]}
+          placeholder={`Select ${(row.fieldName || '').toLowerCase()}`}
         />
       );
     default:

--- a/src/components/ItemName.tsx
+++ b/src/components/ItemName.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
 import RESOURCE_MAP from 'common/RESOURCE_MAP';
+import React from 'react';
+
+import { TEntity } from 'common/typedefs';
+import { IResource } from 'common/typedefs/Resource';
 
 interface IItemNameProps {
   id: string;
@@ -9,13 +12,17 @@ interface IItemNameProps {
 class ItemName extends React.Component<IItemNameProps, { name: string }> {
   state = { name: '' };
   async fetchName(props: IItemNameProps) {
-    const { type, id } = props;
-    const { getName = ({ name }) => name, getItem } = RESOURCE_MAP[type];
+    const { type, id }: IItemNameProps = props;
+    const { getName = ({ name }) => name, getItem }: IResource = RESOURCE_MAP[type];
     if (id === 'create') {
       this.setState({ name: id });
     } else {
-      const item = await getItem(id);
-      this.setState({ name: item ? getName(item) : id });
+      if (getItem) {
+        const item: TEntity | string = await getItem(id);
+        this.setState({ name: item ? getName(item) : id });
+      } else {
+        return '';
+      }
     }
   }
 

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import Truncate from 'react-truncate';
 
 import { TEAL } from 'common/colors';
+import { getApiKeyStatus } from 'components/Associator/apiKeysUtils';
 import Ripple from 'components/Ripple';
 import UserDisplayName, { ChildUserDisplayName } from 'components/UserDisplayName';
-import { getApiKeyStatus } from 'components/Associator/apiKeysUtils';
 
 const styles = {
   container: {

--- a/src/components/ListPane/ItemTable.tsx
+++ b/src/components/ListPane/ItemTable.tsx
@@ -7,6 +7,7 @@ import ReactTable from 'react-table';
 import { compose, defaultProps, withHandlers, withPropsOnChange } from 'recompose';
 import { Button } from 'semantic-ui-react';
 
+import { isChildOfPolicy, isGroup, isUserPermission } from 'common/associatedUtils';
 import { messenger } from 'common/injectGlobals';
 
 import { DARK_GREY, GREY, LIGHT_TEAL, TEAL, VERY_LIGHT_TEAL } from 'common/colors';
@@ -79,17 +80,13 @@ const styles = {
 };
 
 const getColumns = (currentSort, resource, parent) => {
-  const isChildOfPolicy = parent && parent.resource.name.singular === 'policy';
-  let schema = isChildOfPolicy ? resource.childSchema : resource.schema;
+  let schema = isChildOfPolicy(get(parent, 'resource')) ? resource.childSchema : resource.schema;
 
-  if (parent && parent.resource.name.plural === 'groups') {
+  if (parent && isGroup(parent.resource)) {
     schema = reject(schema, c => c.key === 'ownerType');
   }
 
-  if (
-    isEmpty(parent) ||
-    (parent && parent.resource.name.singular === 'user' && resource.name.singular === 'permission')
-  ) {
+  if (isEmpty(parent) || isUserPermission(parent.resource, resource)) {
     schema = reject(schema, c => c.key === 'action');
   }
 

--- a/src/components/ListPane/ItemTable.tsx
+++ b/src/components/ListPane/ItemTable.tsx
@@ -8,8 +8,8 @@ import { compose, defaultProps, withHandlers, withPropsOnChange } from 'recompos
 import { Button } from 'semantic-ui-react';
 
 import { isChildOfPolicy, isGroup, isUserPermission } from 'common/associatedUtils';
-import { messenger } from 'common/injectGlobals';
 import { DARK_GREY, GREY, LIGHT_TEAL, TEAL, VERY_LIGHT_TEAL } from 'common/colors';
+import { messenger } from 'common/injectGlobals';
 
 import ActionButton from 'components/Associator/ActionButton';
 

--- a/src/components/ListPane/ListPane.tsx
+++ b/src/components/ListPane/ListPane.tsx
@@ -107,7 +107,7 @@ class List extends React.Component<IListProps, any> {
       effects: { updateList, setListResource },
     } = this.props;
 
-    await setListResource(resource);
+    await setListResource(resource, parent);
 
     updateList({
       offset,
@@ -157,7 +157,7 @@ class List extends React.Component<IListProps, any> {
     } = this.props;
 
     const displayMode: any =
-      typeof listDisplayMode !== 'undefined' ? listDisplayMode : DisplayMode.Grid;
+      typeof listDisplayMode !== 'undefined' ? listDisplayMode : DisplayMode.Table;
     const isChildOfPolicy = parent && parent.resource.name.singular === 'policy';
     return (
       <div className={`List ${css(styles.container)}`}>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -65,7 +65,11 @@ class Nav extends React.Component<any, any> {
                 >
                   <div className="content">
                     <resource.Icon style={{ opacity: 0.9 }} />
-                    <span className="text">{_.capitalize(`${resource.name.plural}`)}</span>
+                    {collapsed ? (
+                      <div style={{ height: 35 }} />
+                    ) : (
+                      <span className="text">{_.capitalize(`${resource.name.plural}`)}</span>
+                    )}
                   </div>
                 </Ripple>
               </li>

--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -11,6 +11,7 @@ import { NavLink } from 'react-router-dom';
 import { compose } from 'recompose';
 import { provideList } from 'stateProviders';
 
+import { PERMISSIONS } from 'common/enums';
 import { getListFunc } from 'stateProviders/provideEntity';
 
 const enhance = compose(
@@ -52,7 +53,7 @@ const ResourceExplorer = ({ id, resource, history, parent }) => {
                       editing={editing}
                       fetchItems={
                         RESOURCE_MAP[associatedType][
-                          associatedType === 'permissions' ? 'getListAll' : 'getList'
+                          associatedType === PERMISSIONS ? 'getListAll' : 'getList'
                         ]
                       }
                       fetchExistingAssociations={params => {

--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -81,8 +81,6 @@ const ResourceExplorer = ({ id, resource, history, parent }) => {
                       associated[associatedType].count >
                         get(associated[associatedType], 'resultSet.length', 0) && (
                         <NavLink
-                          // TODO: this link can be incorrect if scroll is positioned directly ovet sidenav
-                          // clicking link will take you to one of the entities in sidenav
                           to={`/${resource.name.plural}/${id}/${associatedType}`}
                           style={{
                             color: MEDIUM_BLUE,

--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -69,7 +69,6 @@ const ResourceExplorer = ({ id, resource, history, parent }) => {
                       getName={RESOURCE_MAP[associatedType].getName}
                       initialItems={associated[associatedType].resultSet}
                       onAdd={item => {
-                        console.log('ON ADD: ', item);
                         stageChange({ [associatedType]: { add: item } });
                       }}
                       onRemove={item => stageChange({ [associatedType]: { remove: item } })}

--- a/src/components/ResourceExplorer.tsx
+++ b/src/components/ResourceExplorer.tsx
@@ -11,6 +11,8 @@ import { NavLink } from 'react-router-dom';
 import { compose } from 'recompose';
 import { provideList } from 'stateProviders';
 
+import { getListFunc } from 'stateProviders/provideEntity';
+
 const enhance = compose(
   withRouter,
   provideList,
@@ -48,20 +50,28 @@ const ResourceExplorer = ({ id, resource, history, parent }) => {
                   <React.Fragment>
                     <Associator
                       editing={editing}
-                      fetchItems={RESOURCE_MAP[associatedType].getList}
+                      fetchItems={
+                        RESOURCE_MAP[associatedType][
+                          associatedType === 'permissions' ? 'getListAll' : 'getList'
+                        ]
+                      }
                       fetchExistingAssociations={params => {
                         // prevent 400 error on /create
                         if (id === 'create') {
                           return () => null;
                         }
-                        return RESOURCE_MAP[associatedType].getList({
+
+                        return getListFunc(associatedType, resource)({
                           ...params,
                           [`${resource.name.singular}Id`]: id,
                         });
                       }}
                       getName={RESOURCE_MAP[associatedType].getName}
                       initialItems={associated[associatedType].resultSet}
-                      onAdd={item => stageChange({ [associatedType]: { add: item } })}
+                      onAdd={item => {
+                        console.log('ON ADD: ', item);
+                        stageChange({ [associatedType]: { add: item } });
+                      }}
                       onRemove={item => stageChange({ [associatedType]: { remove: item } })}
                       type={associatedType}
                       resource={resource}

--- a/src/services/getGroup.ts
+++ b/src/services/getGroup.ts
@@ -57,6 +57,7 @@ export const getGroupPermissions = ({
       )}`,
     )
     .then(r => {
+      // TODO: implement server side sorting and search
       // for client side pagination
       const sortBy = sortField !== 'policy' ? sortField : 'policy.name';
       const order = sortOrder || 'desc';

--- a/src/services/getGroup.ts
+++ b/src/services/getGroup.ts
@@ -1,5 +1,8 @@
 import { USE_DUMMY_DATA } from 'common/injectGlobals';
-import _ from 'lodash';
+import { Group } from 'common/typedefs/Group';
+import { find, isNil, omitBy } from 'lodash';
+import queryString from 'querystring';
+
 import ajax from 'services/ajax';
 import dummyApplications from './dummyData/applications';
 import dummyGroups from './dummyData/groups';
@@ -22,9 +25,48 @@ export const getGroupUsers = id => {
 export const getGroupApplications = id => {
   return USE_DUMMY_DATA
     ? Promise.resolve(
-        (_.find(dummyGroups, group => id === group.id, {}).applications || []).map(appId =>
+        (find(dummyGroups, group => id === group.id, {}).applications || []).map(appId =>
           dummyApplications.find(application => appId === application.id),
         ),
       )
     : ajax.get(`/groups/${id}/applications`).then(r => r.data);
+};
+
+export const getGroupPermissions = ({
+  groupId,
+  limit = 20,
+  offset = 0,
+  query = null,
+  sortField = null,
+  sortOrder = null,
+  status = null,
+}): Promise<{ count: number; resultSet: Group[]; offset: number; limit: number }> => {
+  return ajax
+    .get(
+      `/groups/${groupId}/permissions?${queryString.stringify(
+        omitBy(
+          {
+            limit,
+            name: query,
+            offset,
+            sort: sortField,
+            sortOrder,
+          },
+          isNil,
+        ),
+      )}`,
+    )
+    .then(r => {
+      // TODO: do you want to/can you move this mapping to RESOURCE_MAP?
+      return {
+        ...r.data,
+        resultSet: r.data.resultSet.map(result => ({
+          id: result.policy.id,
+          name: result.policy.name,
+          mask: result.accessLevel,
+        })),
+      };
+      // return r.data;
+    })
+    .catch(err => err);
 };

--- a/src/services/getGroup.ts
+++ b/src/services/getGroup.ts
@@ -56,17 +56,6 @@ export const getGroupPermissions = ({
         ),
       )}`,
     )
-    .then(r => {
-      // TODO: do you want to/can you move this mapping to RESOURCE_MAP?
-      return {
-        ...r.data,
-        resultSet: r.data.resultSet.map(result => ({
-          id: result.policy.id,
-          name: result.policy.name,
-          mask: result.accessLevel,
-        })),
-      };
-      // return r.data;
-    })
+    .then(r => r.data)
     .catch(err => err);
 };

--- a/src/services/getGroup.ts
+++ b/src/services/getGroup.ts
@@ -39,7 +39,6 @@ export const getGroupPermissions = ({
   query = null,
   sortField = null,
   sortOrder = null,
-  status = null,
 }): Promise<{ count: number; resultSet: Group[]; offset: number; limit: number }> => {
   return ajax
     .get(

--- a/src/services/getGroup.ts
+++ b/src/services/getGroup.ts
@@ -71,8 +71,7 @@ export const getGroupPermissions = ({
           [sortBy],
           [order.toLowerCase()],
         ).filter(
-          ({ accessLevel, ownerType, policy: { name } }) =>
-            queryBy.test(accessLevel) || queryBy.test(ownerType) || queryBy.test(name),
+          ({ accessLevel, policy: { name } }) => queryBy.test(accessLevel) || queryBy.test(name),
         ),
       };
     })

--- a/src/services/getGroups.ts
+++ b/src/services/getGroups.ts
@@ -55,27 +55,6 @@ export const getGroups = ({
             ),
           )}`,
         )
-        .then(r => {
-          // TODO: use if cannot implement proper sort/search/pagination on backend for policies
-          // if (policyId) {
-          //   const sortBy = sortField;
-          //   const order = sortOrder || 'desc';
-          //   const queryBy = new RegExp(query ? `(${query})` : '', 'i');
-          //   return {
-          //     count: r.data.count,
-          //     limit,
-          //     offset,
-          //     resultSet: orderBy(
-          //       r.data.resultSet.slice(offset, offset + limit),
-          //       [sortBy],
-          //       [order.toLowerCase()],
-          //     ).filter(
-          //       ({ mask, id, name }) =>
-          //         queryBy.test(name) || queryBy.test(mask) || queryBy.test(id),
-          //     ),
-          //   };
-          // }
-          return r.data;
-        })
+        .then(r => r.data)
         .catch(err => err);
 };

--- a/src/services/getGroups.ts
+++ b/src/services/getGroups.ts
@@ -1,6 +1,6 @@
 import { USE_DUMMY_DATA } from 'common/injectGlobals';
 import { Group } from 'common/typedefs/Group';
-import { isNil, omitBy, orderBy } from 'lodash';
+import { isNil, isNull, omitBy, orderBy } from 'lodash';
 import queryString from 'querystring';
 import ajax from 'services/ajax';
 
@@ -30,6 +30,13 @@ export const getGroups = ({
   if (activeId === 'create') {
     Promise.resolve(activeId);
   }
+
+  const policyChildrenSortFields = {
+    mask: 'accessLevel',
+    name: 'owner',
+    id: 'owner',
+  };
+
   return USE_DUMMY_DATA
     ? Promise.resolve({
         count: dummyGroups.length,
@@ -42,12 +49,9 @@ export const getGroups = ({
               {
                 limit,
                 offset,
-                // TODO: using client side or server side pagination for policy/assoc?
-                // query: policyId ? null : query,
-                // sort: policyId ? null : sortField,
                 query,
                 // seems like backend sort for accessLevel is based on hierarchy of levels, not alphabetically?
-                sort: sortField === 'mask' ? 'accessLevel' : sortField,
+                sort: isNil(policyId) ? sortField : policyChildrenSortFields[String(sortField)],
                 sortOrder,
                 status: status === 'All' ? null : status,
               },

--- a/src/services/getUser.ts
+++ b/src/services/getUser.ts
@@ -37,7 +37,7 @@ export const getUserApplications = id => {
 };
 
 export const getUserAndUserGroupPermissions = ({
-  userId = null,
+  userId,
   offset = 0,
   limit = 20,
   query = null,

--- a/src/services/getUsers.ts
+++ b/src/services/getUsers.ts
@@ -30,6 +30,12 @@ export const getUsers = ({
     Promise.resolve(activeId);
   }
 
+  const policyChildrenSortFields = {
+    id: 'owner',
+    mask: 'accessLevel',
+    name: 'owner',
+  };
+
   return USE_DUMMY_DATA
     ? Promise.resolve({
         count: dummyUsers.length,
@@ -42,12 +48,8 @@ export const getUsers = ({
               {
                 limit,
                 offset,
-                // TODO: using client side or server side pagination for policy/assoc?
-                // query: policyId ? null : query,
-                // sort: policyId ? null : sortField,
                 query,
-                // seems like backend sort for accessLevel is based on hierarchy of levels, not alphabetically?
-                sort: sortField === 'mask' ? 'accessLevel' : sortField,
+                sort: isNil(policyId) ? sortField : policyChildrenSortFields[String(sortField)],
                 sortOrder,
                 status: status === 'All' ? null : status,
               },

--- a/src/services/getUsers.ts
+++ b/src/services/getUsers.ts
@@ -55,28 +55,6 @@ export const getUsers = ({
             ),
           )}`,
         )
-        .then(r => {
-          // TODO: use if cannot implement proper sort/search/pagination on backend for policies
-          // if (policyId) {
-          //   const sortBy = sortField;
-          //   const order = sortOrder || 'desc';
-          //   const queryBy = new RegExp(query ? `(${query})` : '', 'i');
-          //
-          //   return {
-          //     count: r.data.count,
-          //     limit,
-          //     offset,
-          //     resultSet: orderBy(
-          //       r.data.resultSet.slice(offset, offset + limit),
-          //       [sortBy],
-          //       [order.toLowerCase()],
-          //     ).filter(
-          //       ({ id, mask, name }) =>
-          //         queryBy.test(name) || queryBy.test(mask) || queryBy.test(id),
-          //     ),
-          //   };
-          // }
-          return r.data;
-        })
+        .then(r => r.data)
         .catch(err => err);
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -15,4 +15,3 @@ export * from './getPolicies';
 export * from './createPolicy';
 export * from './updatePolicy';
 export * from './getApiKeys';
-

--- a/src/stateProviders/provideEntity.ts
+++ b/src/stateProviders/provideEntity.ts
@@ -2,12 +2,13 @@ import { provideState } from 'freactal';
 import { findIndex, isEmpty, omit, uniq } from 'lodash';
 
 import { isGroup, isPolicy } from 'common/associatedUtils';
+import { PERMISSIONS } from 'common/enums';
 import RESOURCE_MAP from 'common/RESOURCE_MAP';
 
 const MAX_ASSOCIATED = 5;
 
 export const getListFunc = (associatedType, parent) =>
-  associatedType === 'permissions' && !isEmpty(parent)
+  associatedType === PERMISSIONS && !isEmpty(parent)
     ? RESOURCE_MAP[associatedType].getList[parent.name.plural]
     : RESOURCE_MAP[associatedType].getList;
 

--- a/src/stateProviders/provideEntity.ts
+++ b/src/stateProviders/provideEntity.ts
@@ -65,7 +65,7 @@ const provideEntity = provideState({
           ...entity.staged,
           ...omit(change, entity.resource.associatedTypes),
         };
-        console.log('start: ', entity.associated);
+
         const stagedEntity = {
           ...state,
           entity: {
@@ -73,7 +73,6 @@ const provideEntity = provideState({
             staged,
             valid: entity.resource.schema.filter(f => f.required).every(f => staged[f.key]),
             associated: Object.keys(entity.associated).reduce((acc, currentType) => {
-              // console.log('ACC: ', acc);
               if (change[currentType]) {
                 return {
                   ...acc,
@@ -93,7 +92,6 @@ const provideEntity = provideState({
                           e => e.id && e.id === change[currentType][action].id,
                         );
                         return {
-                          ...acc,
                           [action]: [
                             ...entity.associated[currentType][action].slice(0, indexToChange),
                             change[currentType][action],
@@ -115,19 +113,6 @@ const provideEntity = provideState({
                           ),
                         };
                       } else {
-                        // const wat = uniq;
-                        // if (currentType === 'permissions') {
-                        // debugger;
-                        // }
-                        const foo = {
-                          ...acc,
-                          [action]: uniq([
-                            ...(entity.associated[currentType][action] || []),
-                            change[currentType][action],
-                          ]),
-                        };
-                        // console.log('FOO: ', foo);
-                        // return foo;
                         return {
                           [action]: uniq([
                             ...(entity.associated[currentType][action] || []),
@@ -144,15 +129,7 @@ const provideEntity = provideState({
             }, {}),
           },
         };
-        console.log('staged entity: ', stagedEntity);
-        // to disable Save when adding new permissions on policies tab
-        // if (
-        //   stagedEntity.entity.associated &&
-        //   stagedEntity.entity.associated.permissions.add.length > 0
-        // ) {
-        //   debugger;
-        // }
-        // console.log('STAGED: ', stagedEntity.entity.associated);
+        // to disable Save when adding new permissions on policies/groups tab
         return {
           ...stagedEntity,
           entity: {
@@ -162,7 +139,7 @@ const provideEntity = provideState({
               (entity.resource.name.singular === 'policy'
                 ? (stagedEntity.entity.associated.groups.add || []).every(a => a.mask) &&
                   (stagedEntity.entity.associated.users.add || []).every(a => a.mask)
-                : entity.resource.name.singular === 'groups'
+                : entity.resource.name.plural === 'groups'
                 ? (stagedEntity.entity.associated.permissions.add || []).every(a => a.mask)
                 : true),
           },

--- a/src/stateProviders/provideEntity.ts
+++ b/src/stateProviders/provideEntity.ts
@@ -1,12 +1,12 @@
 import { provideState } from 'freactal';
-import { findIndex, omit, uniq } from 'lodash';
+import { findIndex, isEmpty, omit, uniq } from 'lodash';
 
 import RESOURCE_MAP from 'common/RESOURCE_MAP';
 
 const MAX_ASSOCIATED = 5;
 
 export const getListFunc = (associatedType, parent) =>
-  associatedType === 'permissions'
+  associatedType === 'permissions' && !isEmpty(parent)
     ? RESOURCE_MAP[associatedType].getList[parent.name.plural]
     : RESOURCE_MAP[associatedType].getList;
 

--- a/src/stateProviders/provideEntity.ts
+++ b/src/stateProviders/provideEntity.ts
@@ -1,6 +1,7 @@
 import { provideState } from 'freactal';
 import { findIndex, isEmpty, omit, uniq } from 'lodash';
 
+import { isGroup, isPolicy } from 'common/associatedUtils';
 import RESOURCE_MAP from 'common/RESOURCE_MAP';
 
 const MAX_ASSOCIATED = 5;
@@ -130,10 +131,10 @@ const provideEntity = provideState({
             ...stagedEntity.entity,
             valid:
               stagedEntity.entity.valid &&
-              (entity.resource.name.singular === 'policy'
+              (isPolicy(entity.resource)
                 ? (stagedEntity.entity.associated.groups.add || []).every(a => a.mask) &&
                   (stagedEntity.entity.associated.users.add || []).every(a => a.mask)
-                : entity.resource.name.plural === 'groups'
+                : isGroup(entity.resource)
                 ? (stagedEntity.entity.associated.permissions.add || []).every(a => a.mask)
                 : true),
           },


### PR DESCRIPTION
Adds permissions to group panel
- client side sorting and search on `/group/permissions`
- disables sort on `name` field for `/policies/{id}/{users/groups}` until server side fix
- fixes user panel update when api key revoked from child table
- removes item from selector dropdown when selected on edit. hides already selected items
- removes list limit on edit dropdown
- clears staged changes on cancel edit
- corrects columns on tables based on parent and child type
- sets default displayMode to table
- adds clear function to search input
- fixes nav link overriding table rows when nav is collapsed
- disables save when new permissions added without setting accessLevel