### PR TITLE
💄 Truncate permission name to prevent table overflow

### DIFF
--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -1,11 +1,9 @@
-import { DEFAULT_BLACK, LIGHT_TEAL, MEDIUM_BLUE } from 'common/colors';
-import Downshift from 'downshift';
+import { DEFAULT_BLACK, LIGHT_TEAL } from 'common/colors';
 import { injectState } from 'freactal';
-import { css } from 'glamor';
-import { capitalize, find, findIndex, get, isEmpty, toLowerCase, uniqBy } from 'lodash';
+import { capitalize, get, truncate } from 'lodash';
 import React from 'react';
 import { compose, defaultProps, withHandlers, withProps, withState } from 'recompose';
-import { Button, Checkbox, Icon, Input, Label, Menu, Table } from 'semantic-ui-react';
+import { Button, Checkbox, Label, Table } from 'semantic-ui-react';
 
 import { MASK_LEVELS } from 'common/injectGlobals';
 
@@ -99,7 +97,7 @@ const PermissionsTable = ({
             return (
               <Table.Row key={item.id}>
                 <Table.Cell>
-                  <span>{item.name}</span>
+                  <span>{truncate(item.name, { length: 28 })}</span>
                 </Table.Cell>
                 <Table.Cell collapsing>
                   {editing ? (

--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_BLACK, LIGHT_TEAL } from 'common/colors';
 import { injectState } from 'freactal';
-import { capitalize, get, truncate } from 'lodash';
+import { capitalize, get } from 'lodash';
 import React from 'react';
 import { compose, defaultProps, withHandlers, withProps, withState } from 'recompose';
 import { Button, Checkbox, Label, Table } from 'semantic-ui-react';
@@ -97,7 +97,17 @@ const PermissionsTable = ({
             return (
               <Table.Row key={item.id}>
                 <Table.Cell>
-                  <span>{truncate(item.name, { length: 28 })}</span>
+                  <span
+                    style={{
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis',
+                      width: 170,
+                      display: 'inline-block',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {item.name}
+                  </span>
                 </Table.Cell>
                 <Table.Cell collapsing>
                   {editing ? (


### PR DESCRIPTION
Truncates permission names longer than 28 characters to prevent edit mode table row extending off the screen.