### PR TITLE
🐛 Prevent undefined item being added to items list

### DIFF
--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -54,7 +54,7 @@ async function fetchAllAssociatedItems({
 
   do {
     const data = await fetchExistingAssociations({ limit: 1000 });
-    items = [...items, ...(data ? data.resultSet : [])];
+    items = [...items, ...(get(data, 'resultSet') || [])];
     count = data ? data.count : 0;
   } while (items.length < count);
 


### PR DESCRIPTION
Fixes crash when clicking `Create` on the group panel.
- prevents an undefined item from being added to the list of associated items for an entity.