### PR TITLE
💄 Width adjustments for permissions tables

### DIFF
--- a/src/components/Associator/PermissionsTable.tsx
+++ b/src/components/Associator/PermissionsTable.tsx
@@ -102,7 +102,7 @@ const PermissionsTable = ({
                     style={{
                       whiteSpace: 'nowrap',
                       textOverflow: 'ellipsis',
-                      width: 170,
+                      width: editing ? 165 : 370,
                       display: 'inline-block',
                       overflow: 'hidden',
                     }}

--- a/src/components/Associator/UserPermissionsTable.tsx
+++ b/src/components/Associator/UserPermissionsTable.tsx
@@ -17,7 +17,17 @@ export default ({ associatedItems }) => (
         {associatedItems.map(item => (
           <Table.Row key={item.policy.id}>
             <Table.Cell>
-              <span>{item.policy.name}</span>
+              <span
+                style={{
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                  width: 280,
+                  display: 'inline-block',
+                  overflow: 'hidden',
+                }}
+              >
+                {item.policy.name}
+              </span>
             </Table.Cell>
             <Table.Cell collapsing>
               <Label style={styles.label}>


### PR DESCRIPTION
Adjusted width for non-edit mode as there is more space.
Applied adjustments to user permissions table, no edit mode needed.