### PR TITLE
💄 125 - Conditional display name for users. Restore mutable first, lastname

### DIFF
--- a/src/common/RESOURCE_MAP.tsx
+++ b/src/common/RESOURCE_MAP.tsx
@@ -58,7 +58,6 @@ import { IResource, TResourceType } from 'common/typedefs/Resource';
 import { Icon } from 'semantic-ui-react';
 
 import {
-  API_KEY,
   API_KEYS,
   APPLICATION,
   APPLICATIONS,
@@ -71,6 +70,7 @@ import {
   USER,
   USERS,
 } from 'common/enums';
+import { getUserDisplayName } from './getUserDisplayName';
 
 // ignore tslint sort, resources listed in deliberate order
 const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
@@ -100,7 +100,7 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
     getKey: item => item.id.toString(),
     getList: getUsers,
     getListAll: getUsers,
-    getName: x => `${x.lastName}, ${x.firstName ? x.firstName[0] : undefined}`, // Null safe property access
+    getName: getUserDisplayName,
     Icon: ({ style }) => <Icon name="user" style={style} />,
     initialSortOrder: 'ASC',
     isParent: true,
@@ -132,18 +132,14 @@ const RESOURCE_MAP: { [key in TResourceType]: IResource } = {
         fieldName: 'First Name',
         key: 'firstName',
         panelSection: null,
-        required: true,
         sortable: true,
-        immutable: true,
       },
       {
         fieldName: 'Last Name',
         initialSort: true,
         key: 'lastName',
         panelSection: 'id',
-        required: true,
         sortable: true,
-        immutable: true,
       },
       {
         fieldName: 'Email',

--- a/src/common/getUserDisplayName.ts
+++ b/src/common/getUserDisplayName.ts
@@ -1,0 +1,18 @@
+import { User } from './typedefs';
+
+export const getUserDisplayName: (user: User) => string = user => {
+  // Ego enforces that if there is only one name value from a provider, it will be firstName,
+  // but this can be edited in ego-ui so we need to check that we have firstName or lastName only
+  if (user.firstName.length) {
+    if (user.lastName.length) {
+      return `${user.lastName}, ${user.firstName[0]}`;
+    }
+    return user.firstName;
+  } else if (user.lastName.length) {
+    return user.lastName;
+  } else if (user.email) {
+    return user.email;
+  } else {
+    return user.id;
+  }
+};

--- a/src/common/typedefs/User.d.ts
+++ b/src/common/typedefs/User.d.ts
@@ -1,8 +1,20 @@
+enum EgoProviderType {
+  GOOGLE = 'GOOGLE',
+  FACEBOOK = 'FACEBOOK',
+  GITHUB = 'GITHUB',
+  LINKEDIN = 'LINKEDIN',
+  ORCID = 'ORCID',
+}
+
+enum UserType {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+}
+
 export interface User {
   id: string;
-  userName: string;
   email: string;
-  type: string;
+  type: UserType;
   status: string;
   firstName: string;
   lastName: string;
@@ -10,4 +22,6 @@ export interface User {
   createdAt: string;
   preferredLanguage: string;
   groups: string[];
+  providerSubjectId: string;
+  providerType: EgoProviderType;
 }

--- a/src/components/Associator/Associator.tsx
+++ b/src/components/Associator/Associator.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { compose, defaultProps, lifecycle, withStateHandlers } from 'recompose';
 import { Icon, Label } from 'semantic-ui-react';
 
-import { DARK_BLUE, DARK_GREY, GREY, HIGH_CONTRAST_TEAL } from 'common/colors';
+import { DARK_BLUE, DARK_GREY, GREY } from 'common/colors';
 import { messenger } from 'common/injectGlobals';
 import RESOURCE_MAP from 'common/RESOURCE_MAP';
 import { IResource } from 'common/typedefs/Resource';
@@ -15,6 +15,7 @@ import ItemSelector from './ItemSelector';
 
 import { isGroup } from 'common/associatedUtils';
 import { API_KEYS, PERMISSIONS, USERS } from 'common/enums';
+import { getUserDisplayName } from 'common/getUserDisplayName';
 
 interface TProps {
   addItem: Function;
@@ -172,7 +173,7 @@ const Associator = ({
         }))
       : allAssociatedItems;
 
-  const getUserDisplayName = item => {
+  const getListDisplayNameForUser = item => {
     return (
       <div>
         <span>{RESOURCE_MAP[USERS].getName(item)}</span>
@@ -208,13 +209,11 @@ const Associator = ({
             fetchItems={args => fetchItems({ ...args, limit: 1000 })}
             onSelect={item => addItem(item, type)}
             disabledItems={uniqBy([...parsedAssocItems, ...itemsInList], item => item && item.id)}
-            getItemName={item => (type === USERS ? getUserDisplayName(item) : get(item, 'name'))}
+            getItemName={item =>
+              type === USERS ? getListDisplayNameForUser(item) : get(item, 'name')
+            }
             getName={item =>
-              item
-                ? type === USERS
-                  ? `${item.firstName} ${item.lastName}`
-                  : get(item, 'name')
-                : ''
+              item ? (type === USERS ? getUserDisplayName(item) : get(item, 'name')) : ''
             }
             type={type}
           />

--- a/src/components/Associator/ItemSelector.tsx
+++ b/src/components/Associator/ItemSelector.tsx
@@ -1,4 +1,5 @@
 import { USERS } from 'common/enums';
+import { getUserDisplayName } from 'common/getUserDisplayName';
 import Downshift from 'downshift';
 import { css } from 'glamor';
 import { differenceBy, get } from 'lodash';
@@ -36,7 +37,7 @@ const enhance = compose(
           type === USERS
             ? {
                 ...item,
-                name: `${item.firstName} ${item.lastName}`,
+                name: getUserDisplayName(item),
               }
             : item;
         onSelect(itemToAdd);
@@ -83,17 +84,15 @@ const render = ({
     if (items.length === 0 || availableItems.length === 0) {
       return <Menu.Item>No Results</Menu.Item>;
     }
+
     return availableItems.filter(matchFor(inputValue, getName)).map((item, i) => {
-      const isDisabled = disabledItems.map(getKey).includes(getKey(item));
       return (
         <Menu.Item
           key={getKey(item)}
           {...getItemProps({
-            disabled: isDisabled,
             item,
           })}
           active={highlightedIndex === i}
-          disabled={isDisabled}
         >
           {getItemName(item)}
         </Menu.Item>

--- a/src/components/Content/ContentPanel.tsx
+++ b/src/components/Content/ContentPanel.tsx
@@ -1,22 +1,26 @@
 import format from 'date-fns/format/index.js';
 import { injectState } from 'freactal';
-import { css } from 'glamor';
-import { groupBy, upperCase } from 'lodash';
+import { upperCase } from 'lodash';
 import React from 'react';
 import { compose } from 'recompose';
-import { Grid } from 'semantic-ui-react';
 
 import { DATE_FORMAT, DATE_KEYS } from 'common/injectGlobals';
 import ContentPanelView from './ContentPanelView';
+
+const EmptyField = () => <span style={{ opacity: 0.4, fontStyle: 'italic' }}>empty</span>
 
 export const getFieldContent = (row, data) => {
   if (DATE_KEYS.indexOf(row.key) >= 0) {
     return format(data[row.key], DATE_FORMAT);
   }
   if (row.key === 'lastName') {
-    return `${data.firstName} ${data.lastName}`;
+    if (!data?.firstName.length && !data?.lastName.length) {
+      return <EmptyField />
+    }
+    return [data.firstName, data.lastName].join(' ')
   }
-  return data[row.key];
+  return data[row.key] || <EmptyField />
+
 };
 
 export const getUserFieldName = row => {
@@ -28,15 +32,10 @@ function normalizeRow(
   data: object[],
   associated: any,
 ) {
+
   const rowData = {
     ...row,
-    fieldContent:
-      row.fieldContent ||
-      (data[row.key] ? (
-        getFieldContent(row, data)
-      ) : (
-        <span style={{ opacity: 0.4, fontStyle: 'italic' }}>empty</span>
-      )),
+    fieldContent: row.fieldContent || getFieldContent(row, data),
     fieldName: getUserFieldName(row),
   };
 
@@ -62,7 +61,6 @@ const ContentPanel = ({
     entity: { item, associated, resource },
   },
 }) => {
-  const panelSections = groupBy(rows, 'panelSection');
   const normalizedRows = rows.map(row => normalizeRow(row, item, associated));
   return (
     <ContentPanelView

--- a/src/components/Content/ContentPanel.tsx
+++ b/src/components/Content/ContentPanel.tsx
@@ -7,20 +7,19 @@ import { compose } from 'recompose';
 import { DATE_FORMAT, DATE_KEYS } from 'common/injectGlobals';
 import ContentPanelView from './ContentPanelView';
 
-const EmptyField = () => <span style={{ opacity: 0.4, fontStyle: 'italic' }}>empty</span>
+const EmptyField = () => <span style={{ opacity: 0.4, fontStyle: 'italic' }}>empty</span>;
 
 export const getFieldContent = (row, data) => {
   if (DATE_KEYS.indexOf(row.key) >= 0) {
     return format(data[row.key], DATE_FORMAT);
   }
   if (row.key === 'lastName') {
-    if (!data?.firstName.length && !data?.lastName.length) {
-      return <EmptyField />
+    if (!data.firstName.length && !data.lastName.length) {
+      return <EmptyField />;
     }
-    return [data.firstName, data.lastName].join(' ')
+    return [data.firstName, data.lastName].join(' ');
   }
-  return data[row.key] || <EmptyField />
-
+  return data[row.key] || <EmptyField />;
 };
 
 export const getUserFieldName = row => {
@@ -32,7 +31,6 @@ function normalizeRow(
   data: object[],
   associated: any,
 ) {
-
   const rowData = {
     ...row,
     fieldContent: row.fieldContent || getFieldContent(row, data),

--- a/src/components/Content/ContentPanel.tsx
+++ b/src/components/Content/ContentPanel.tsx
@@ -10,6 +10,9 @@ import ContentPanelView from './ContentPanelView';
 const EmptyField = () => <span style={{ opacity: 0.4, fontStyle: 'italic' }}>empty</span>;
 
 export const getFieldContent = (row, data) => {
+  if (row.fieldContent) {
+    return row.fieldContent;
+  }
   if (DATE_KEYS.indexOf(row.key) >= 0) {
     return format(data[row.key], DATE_FORMAT);
   }
@@ -33,7 +36,7 @@ function normalizeRow(
 ) {
   const rowData = {
     ...row,
-    fieldContent: row.fieldContent || getFieldContent(row, data),
+    fieldContent: getFieldContent(row, data),
     fieldName: getUserFieldName(row),
   };
 

--- a/src/components/Content/EditingContentPanel.tsx
+++ b/src/components/Content/EditingContentPanel.tsx
@@ -13,18 +13,14 @@ import { getUserFieldName } from './ContentPanel';
 import ContentPanelView from './ContentPanelView';
 
 const getFieldContent = (row, data, immutableKeys, stageChange) => {
-  if (row.key === 'lastName') {
-    return `${data.firstName} ${data.lastName}`;
-  } else {
-    return (
-      row.fieldContent ||
-      (immutableKeys.includes(row.key)
-        ? DATE_KEYS.indexOf(row.key) >= 0
-          ? format(data[row.key], DATE_FORMAT)
-          : data[row.key] || ''
-        : rowInput({ row, data, stageChange }))
-    );
-  }
+  return (
+    row.fieldContent ||
+    (immutableKeys.includes(row.key)
+      ? DATE_KEYS.indexOf(row.key) >= 0
+        ? format(data[row.key], DATE_FORMAT)
+        : data[row.key] || ''
+      : rowInput({ row, data, stageChange }))
+  );
 };
 
 function rowInput({
@@ -51,6 +47,15 @@ function rowInput({
     default:
       return (
         <div style={{ display: 'flex', flex: '0 0 100%' }}>
+          {row.key === 'lastName' ? (
+            <Input
+              className={`firstName ${css({ marginRight: 10 })}`}
+              size="mini"
+              onChange={(e, { value }) => stageChange({ firstName: value })}
+              type="text"
+              value={data['firstName'] || ''}
+            />
+          ) : null}
           <Input
             size="mini"
             onChange={(e, { value }) => stageChange({ [row.key]: value })}

--- a/src/components/ItemName.tsx
+++ b/src/components/ItemName.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 
 import { TEntity } from 'common/typedefs';
 import { IResource } from 'common/typedefs/Resource';
+import { css } from 'glamor';
 
 interface IItemNameProps {
   id: string;
   type: string;
+  className?: any;
 }
 
 class ItemName extends React.Component<IItemNameProps, { name: string }> {
@@ -36,7 +38,7 @@ class ItemName extends React.Component<IItemNameProps, { name: string }> {
     }
   }
   render() {
-    return this.state.name;
+    return <span className={`${css({ textTransform: 'none' })}`}>{this.state.name}</span>;
   }
 }
 

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -2,11 +2,13 @@ import { css } from 'glamor';
 import { isEmpty } from 'lodash';
 import React from 'react';
 import Truncate from 'react-truncate';
+import format from 'date-fns/format/index.js';
 
 import { TEAL } from 'common/colors';
 import { getApiKeyStatus } from 'components/Associator/apiKeysUtils';
 import Ripple from 'components/Ripple';
-import UserDisplayName, { ChildUserDisplayName } from 'components/UserDisplayName';
+import { UserDisplayName } from 'components/UserDisplayName';
+import { DATE_FORMAT } from 'common/injectGlobals';
 
 const styles = {
   container: {
@@ -72,27 +74,26 @@ export const ApplicationListItem = ({ item, sortField, className = '', style, ..
 };
 
 export const UserListItem = ({ item, sortField, className = '', style, parent, ...props }) => {
-  const { firstName, lastName, name, type } = item;
-
   const secondaryField = sortField === 'lastName' ? 'email' : sortField;
+  const secondaryValue =
+    secondaryField === 'createdAt' || secondaryField === 'lastLogin'
+      ? format(item[secondaryField], DATE_FORMAT)
+      : item[secondaryField];
+
   return (
     <Ripple
       className={`UserListItem ${className}`}
       style={{ ...styles.container, ...style }}
       {...props}
     >
-      {isEmpty(parent) ? (
-        <UserDisplayName firstName={firstName} lastName={lastName} type={type} />
-      ) : (
-        <ChildUserDisplayName name={`${firstName} ${lastName}`} type={type} />
-      )}
-      <div className={`secondary-field ${css(styles.secondaryField)}`}>{item[secondaryField]}</div>
+      <UserDisplayName user={item} />
+      <div className={`secondary-field ${css(styles.secondaryField)}`}>{secondaryValue}</div>
     </Ripple>
   );
 };
 
 export const PolicyListItem = ({ item, sortField, className = '', style, ...props }) => {
-  const { id, name } = item;
+  const { name } = item;
   const secondaryField = sortField === 'name' ? 'id' : sortField;
 
   return (

--- a/src/components/Nav/CurrentUserNavItem.tsx
+++ b/src/components/Nav/CurrentUserNavItem.tsx
@@ -8,6 +8,7 @@ import { compose, withState } from 'recompose';
 import { BLUE, LIGHT_BLUE, TEAL, WHITE } from 'common/colors';
 import Logout from 'components/Logout';
 import Ripple from 'components/Ripple';
+import { getUserDisplayName } from 'common/getUserDisplayName';
 
 const enhance = compose(
   injectState,
@@ -47,6 +48,10 @@ const styles = {
   displayName: {
     marginLeft: 10,
     fontSize: 18,
+    width: '160px',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 
   userActions: {
@@ -90,7 +95,7 @@ const render = ({ state, style, shouldShowMenu, setShouldShowMenu, ref }) => {
           />
         </div>
         <div className={`display-name ${css(styles.displayName)}`}>
-          {state.loggedInUser.firstName}
+          {getUserDisplayName(state.loggedInUser)}
         </div>
         {shouldShowMenu && (
           <div className={`user-actions ${css(styles.userActions)}`}>

--- a/src/components/Nav/Nav.styles.ts
+++ b/src/components/Nav/Nav.styles.ts
@@ -119,7 +119,7 @@ const styles = {
   },
   currentUser: {
     paddingLeft: '20%',
-    paddingRight: '20%',
+    paddingRight: '10%',
     paddingTop: 12,
     paddingBottom: 12,
     cursor: 'pointer',

--- a/src/components/UserDisplayName.tsx
+++ b/src/components/UserDisplayName.tsx
@@ -1,4 +1,5 @@
 import { TEAL } from 'common/colors';
+import { User } from 'common/typedefs/User';
 import { css } from 'glamor';
 import React from 'react';
 
@@ -6,7 +7,6 @@ import Truncate from 'react-truncate';
 
 const styles = {
   container: {
-    width: '160px',
     fontSize: 18,
     lineHeight: 1,
     display: 'flex',
@@ -19,47 +19,35 @@ const styles = {
     color: TEAL,
   },
   formattedName: {
-    '& .name-part': {
-      maxWidth: '7em',
-      overflowX: 'hidden',
-      textOverflow: 'ellipsis',
-      display: 'inline-block',
-      wordBreak: 'break-word',
-      whiteSpace: 'nowrap',
-      lineHeight: 'normal',
-      paddingRight: '0.1em',
-      verticalAlign: 'text-bottom',
-    },
-    '& .punctuation': {
-      display: 'inline-block',
-      marginLeft: '-0.1em',
-    },
+    maxWidth: '180px',
+    overflowX: 'hidden',
+    textOverflow: 'ellipsis',
+    display: 'inline-block',
+    wordBreak: 'break-word',
+    whiteSpace: 'nowrap',
+    lineHeight: 'normal',
+    paddingRight: '0.1em',
+    verticalAlign: 'text-bottom',
   },
 };
 
-const FormatName = ({ firstName = '', lastName = '' }) => (
-  <span className={`formatted-name, ${css(styles.formattedName)}`}>
-    <span className={`last-name name-part`}>{lastName}</span>
-    <span className={`punctuation`}>,</span>{' '}
-    <span className={`first-name name-part`}>
-      {((firstName ? firstName[0] : '') || '').toUpperCase()}
-    </span>
-    <span className={`punctuation`}>.</span>
-  </span>
-);
-
-export const ChildUserDisplayName = ({ name, type }) => {
-  return (
-    <div className={`DisplayName ${css(styles.container)}`}>
-      <Truncate className={`formatted-name, ${css(styles.formattedName)}`}>{name}</Truncate>
-      {type === 'ADMIN' && <div className={`${css(styles.userAdmin)}`}>ADMIN</div>}
-    </div>
-  );
+const getName = user => {
+  const { lastName, firstName, id } = user;
+  if (lastName) {
+    if (firstName) {
+      return `${lastName}, ${firstName[0].toUpperCase()}.`;
+    }
+    return lastName;
+  } else if (firstName) {
+    return firstName;
+  } else {
+    return id;
+  }
 };
 
-export default ({ firstName, lastName, type, style }: any) => (
+export const UserDisplayName = ({ user, style = {} }: { user: User; style?: any }) => (
   <div className={`DisplayName ${css(styles.container, style)}`}>
-    <FormatName firstName={firstName} lastName={lastName} />
-    {type === 'ADMIN' && <div className={`${css(styles.userAdmin)}`}>ADMIN</div>}
+    <span className={`${css(styles.formattedName)}`}>{getName(user)}</span>
+    {user.type === 'ADMIN' && <div className={`${css(styles.userAdmin)}`}>ADMIN</div>}
   </div>
 );

--- a/src/services/updateUser.ts
+++ b/src/services/updateUser.ts
@@ -30,7 +30,7 @@ function remove({ user, key, value }: any) {
 }
 
 export const updateUser = ({ item }) => {
-  return ajax.put(`/users/${item.id}`, omit(item, BLOCKED_KEYS)).then(r => r.data);
+  return ajax.patch(`/users/${item.id}`, omit(item, BLOCKED_KEYS)).then(r => r.data);
 };
 
 export const addGroupToUser = ({ user, group }) => {


### PR DESCRIPTION
Restores editing for first and lastname fields
Adds hierarchy for displaying user names, depending on availability: first and/or lastname -> email -> id
Changes userUpdate `PUT` to `PATCH`
Adds formatting to grid display timestamps