### PR TITLE
Add Copy JWT Option to User Menu

### DIFF
--- a/src/components/Nav/CopyJwt.tsx
+++ b/src/components/Nav/CopyJwt.tsx
@@ -1,0 +1,48 @@
+import { injectState } from 'freactal';
+import { css } from 'glamor';
+import React from 'react';
+import { withRouter } from 'react-router';
+import { compose } from 'recompose';
+
+// This declaration is needed for typescript to compile
+// More recent versions of TS include clipboard on the navigator type
+//   but the current version used here does not. When TS is updated we can
+//   Remove these interface declarations
+interface Clipboard {
+  writeText(newClipText: string): Promise<void>;
+  // Add any other methods you need here.
+}
+interface NavigatorClipboard extends Navigator {
+  // Only available in a secure context.
+  readonly clipboard?: Clipboard;
+}
+interface NavigatorExtended extends NavigatorClipboard {}
+
+const styles = {
+  container: { cursor: 'pointer' },
+};
+
+const enhance = compose(withRouter, injectState);
+
+const CopyJwt = class extends React.Component<any, any> {
+  hasClipboard = !!(navigator as NavigatorExtended).clipboard;
+  handleClick = async () => {
+    const nav = navigator as NavigatorExtended;
+    nav.clipboard && nav.clipboard.writeText(this.props.state.loggedInUserToken);
+  };
+  render() {
+    // Only render this component if the current browser has the clipboard available (HTTPS only)
+    return (
+      this.hasClipboard && (
+        <div
+          className={`${css(styles.container, this.props.styles)} ${this.props.className}`}
+          onClick={this.handleClick}
+        >
+          Copy My JWT
+        </div>
+      )
+    );
+  }
+};
+
+export default enhance(CopyJwt);

--- a/src/components/Nav/CopyJwt.tsx
+++ b/src/components/Nav/CopyJwt.tsx
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 import React from 'react';
 import { withRouter } from 'react-router';
 import { compose } from 'recompose';
+import { Icon } from 'semantic-ui-react';
 
 // This declaration is needed for typescript to compile
 // More recent versions of TS include clipboard on the navigator type
@@ -25,10 +26,19 @@ const styles = {
 const enhance = compose(withRouter, injectState);
 
 const CopyJwt = class extends React.Component<any, any> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      copied: false,
+    };
+  }
   hasClipboard = !!(navigator as NavigatorExtended).clipboard;
   handleClick = async () => {
     const nav = navigator as NavigatorExtended;
+    console.log('copy click', nav.clipboard);
     nav.clipboard && nav.clipboard.writeText(this.props.state.loggedInUserToken);
+    // await new Promise(resolve => setTimeout(resolve, 1600));
+    this.setState({ copied: true });
   };
   render() {
     // Only render this component if the current browser has the clipboard available (HTTPS only)
@@ -38,7 +48,7 @@ const CopyJwt = class extends React.Component<any, any> {
           className={`${css(styles.container, this.props.styles)} ${this.props.className}`}
           onClick={this.handleClick}
         >
-          Copy My JWT
+          Copy My JWT {this.state.copied && <Icon name="check" />}
         </div>
       )
     );

--- a/src/components/Nav/CopyJwt.tsx
+++ b/src/components/Nav/CopyJwt.tsx
@@ -35,9 +35,7 @@ const CopyJwt = class extends React.Component<any, any> {
   hasClipboard = !!(navigator as NavigatorExtended).clipboard;
   handleClick = async () => {
     const nav = navigator as NavigatorExtended;
-    console.log('copy click', nav.clipboard);
     nav.clipboard && nav.clipboard.writeText(this.props.state.loggedInUserToken);
-    // await new Promise(resolve => setTimeout(resolve, 1600));
     this.setState({ copied: true });
   };
   render() {

--- a/src/components/Nav/CurrentUserNavItem.tsx
+++ b/src/components/Nav/CurrentUserNavItem.tsx
@@ -83,7 +83,10 @@ const render = ({ state, style, shouldShowMenu, setShouldShowMenu, ref }) => {
       <Ripple
         className={`CurrentUserNavItem ${css(styles.container, style)}`}
         ref={ref}
-        onClick={() => setShouldShowMenu(!shouldShowMenu)}
+        onClick={() =>
+          // Timeout gives enough delay to see checkmark on copy JWT but is not too long to be annoying on other options
+          setTimeout(() => setShouldShowMenu(!shouldShowMenu), shouldShowMenu ? 500 : 0)
+        }
       >
         <div className={`avatar-container ${css(styles.avatarContainer)}`}>
           <Gravatar

--- a/src/components/Nav/CurrentUserNavItem.tsx
+++ b/src/components/Nav/CurrentUserNavItem.tsx
@@ -8,12 +8,10 @@ import { compose, withState } from 'recompose';
 import { BLUE, LIGHT_BLUE, TEAL, WHITE } from 'common/colors';
 import Logout from 'components/Logout';
 import Ripple from 'components/Ripple';
+import CopyJwt from './CopyJwt';
 import { getUserDisplayName } from 'common/getUserDisplayName';
 
-const enhance = compose(
-  injectState,
-  withState('shouldShowMenu', 'setShouldShowMenu', false),
-);
+const enhance = compose(injectState, withState('shouldShowMenu', 'setShouldShowMenu', false));
 
 const styles = {
   container: {
@@ -99,6 +97,7 @@ const render = ({ state, style, shouldShowMenu, setShouldShowMenu, ref }) => {
         </div>
         {shouldShowMenu && (
           <div className={`user-actions ${css(styles.userActions)}`}>
+            <CopyJwt className={`menu-item ${css(styles.menuItem)}`} />
             <NavLink
               to={`/users/${state.loggedInUser.id}`}
               className={`menu-item ${css(styles.menuItem)}`}


### PR DESCRIPTION
This adds a menu option to the sidebar user menu to "Copy My JWT". Clicking this will copy the logged in user's current JWT to the clipboard and show a little checkmark for visual feedback that the copy worked.

This wasn't requested by anyone but is the result of seeing many people require a JWT for interacting with an API and there not existing a way to access their token in a UI. User's have been retrieving their token through the browser developer tools by copying it out of local storage. This is a convenience in response to that frustrating path.

<img width="490" alt="Screen Shot 2021-03-31 at 9 50 38 AM" src="https://user-images.githubusercontent.com/8339820/113155004-9314b900-9206-11eb-86c7-b5fcd8f19714.png">
